### PR TITLE
Implement transmit only proximity chat

### DIFF
--- a/lua/autorun/client/proximity_voice_init.lua
+++ b/lua/autorun/client/proximity_voice_init.lua
@@ -1,14 +1,28 @@
-local convar = CreateClientConVar( "proximity_voice_enabled", "0", true, true )
+local proximityEnabled = CreateClientConVar( "proximity_voice_enabled", "0", true, true )
+local transmitOnly = CreateClientConVar( "proximity_voice_transmit_only", "0", true, true )
 cvars.AddChangeCallback( "proximity_voice_enabled", function( _, _, new )
     net.Start( "proximity_voice_enabled_changed" )
+        net.WriteBool( tobool( new ) )
+        if new then
+            net.WriteBool( transmitOnly:GetBool() )
+        end
+    net.SendToServer()
+end )
+cvars.AddChangeCallback( "proximity_voice_transmit_only", function( _, _, new )
+    local enabled = proximityEnabled:GetBool()
+    if not enabled then return end
+    net.Start( "proximity_voice_enabled_changed" )
+        net.WriteBool( proximityEnabled:GetBool() )
         net.WriteBool( tobool( new ) )
     net.SendToServer()
 end )
 
-
 local function populatePanel( form )
     local checkbox = form:CheckBox( "Enable Proximity Voice", "proximity_voice_enabled" )
-    checkbox:SetChecked( convar:GetBool() )
+    checkbox:SetChecked( proximityEnabled:GetBool() )
+
+    local checkbox2 = form:CheckBox( "Proximity Voice is transmit only?", "proximity_voice_transmit_only" )
+    checkbox2:SetChecked( transmitOnly:GetBool() )
 end
 
 hook.Add( "AddToolMenuCategories", "CFC_ProximityVoice_AddMenuCategory", function()
@@ -23,6 +37,9 @@ end )
 
 hook.Add( "InitPostEntity", "CFC_ProximityVoice_SendConfigToServer", function()
     net.Start( "proximity_voice_enabled_changed" )
-        net.WriteBool( convar:GetBool() )
+        net.WriteBool( proximityEnabled:GetBool() )
+        if proximityEnabled:GetBool() then
+            net.WriteBool( transmitOnly:GetBool() )
+        end
     net.SendToServer()
 end )

--- a/lua/autorun/client/proximity_voice_init.lua
+++ b/lua/autorun/client/proximity_voice_init.lua
@@ -12,7 +12,7 @@ cvars.AddChangeCallback( "proximity_voice_transmit_only", function( _, _, new )
     local enabled = proximityEnabled:GetBool()
     if not enabled then return end
     net.Start( "proximity_voice_enabled_changed" )
-        net.WriteBool( proximityEnabled:GetBool() )
+        net.WriteBool( enabled )
         net.WriteBool( tobool( new ) )
     net.SendToServer()
 end )

--- a/lua/autorun/server/toggle_voice_init.lua
+++ b/lua/autorun/server/toggle_voice_init.lua
@@ -14,6 +14,8 @@ cvars.AddChangeCallback( "force_proximity_voice", function( _, _, _ )
     end
 end, "force_proximity_voice_callback" )
 
+local TRANSMIT_RECEIVE = 1
+local TRANSMIT_ONLY = 2
 local config = {
     CHAT_DISTANCE = 1000,
     VOICE_3D = true
@@ -48,7 +50,7 @@ function ProximityVoiceOverridePlayerConfig( ply, enabled )
 end
 
 hook.Add( "PlayerCanHearPlayersVoice", "CFC_ToggleLocalVoice_CanHear", function( listener, speaker )
-    local shouldUseLocal = forceLocalVoice or playerConfig[listener] == 1 or playerConfig[speaker] or playerConfigOverride[listener] or playerConfigOverride[speaker]
+    local shouldUseLocal = forceLocalVoice or playerConfig[listener] == TRANSMIT_RECEIVE or playerConfig[speaker] or playerConfigOverride[listener] or playerConfigOverride[speaker]
     if not shouldUseLocal then return end
 
     return canHear( listener, speaker ), VOICE_3D
@@ -61,9 +63,12 @@ end )
 
 util.AddNetworkString( "proximity_voice_enabled_changed" )
 net.Receive( "proximity_voice_enabled_changed", function( _, ply )
-    local enabled, transmitOnly = net.ReadBool(), nil
-    if enabled then
-        transmitOnly = net.ReadBool()
+    local enabled = net.ReadBool()
+    if not enabled then
+        playerConfig[ply] = nil
+    elseif net.ReadBool() then
+        playerConfig[ply] = TRANSMIT_ONLY
+    else
+        playerConfig[ply] = TRANSMIT_RECEIVE
     end
-    playerConfig[ply] = enabled and ( transmitOnly and 2 or 1 ) or nil
 end )

--- a/lua/autorun/server/toggle_voice_init.lua
+++ b/lua/autorun/server/toggle_voice_init.lua
@@ -48,7 +48,7 @@ function ProximityVoiceOverridePlayerConfig( ply, enabled )
 end
 
 hook.Add( "PlayerCanHearPlayersVoice", "CFC_ToggleLocalVoice_CanHear", function( listener, speaker )
-    local shouldUseLocal = forceLocalVoice or playerConfig[listener] or playerConfig[speaker] or playerConfigOverride[listener] or playerConfigOverride[speaker]
+    local shouldUseLocal = forceLocalVoice or playerConfig[listener] == 1 or playerConfig[speaker] or playerConfigOverride[listener] or playerConfigOverride[speaker]
     if not shouldUseLocal then return end
 
     return canHear( listener, speaker ), VOICE_3D
@@ -61,6 +61,9 @@ end )
 
 util.AddNetworkString( "proximity_voice_enabled_changed" )
 net.Receive( "proximity_voice_enabled_changed", function( _, ply )
-    local enabled = net.ReadBool()
-    playerConfig[ply] = enabled or nil
+    local enabled, transmitOnly = net.ReadBool(), nil
+    if enabled then
+        transmitOnly = net.ReadBool()
+    end
+    playerConfig[ply] = enabled and ( transmitOnly and 2 or 1 ) or nil
 end )


### PR DESCRIPTION
This adds a new feature to the Proximity Chat, allowing you to talk in prox chat and hear everyone else that isn't in prox chat.
Base proximity chat is still functional as this adds a new convar and checkbox.
New convar: `proximity_voice_transmit_only`, boolean, only takes effect if `proximity_voice_enabled` is set to `1`