### PR TITLE
Wrap callback object for enabled in tonumber func

### DIFF
--- a/lua/autorun/client/proximity_voice_init.lua
+++ b/lua/autorun/client/proximity_voice_init.lua
@@ -13,7 +13,7 @@ cvars.AddChangeCallback( "proximity_voice_transmit_only", function( _, _, new )
     if not enabled then return end
     net.Start( "proximity_voice_enabled_changed" )
         net.WriteBool( enabled )
-        net.WriteBool( tobool( new ) )
+        net.WriteBool( tobool( tonumber( new ) ) )
     net.SendToServer()
 end )
 


### PR DESCRIPTION
Proximity voice uses `tobool( new )` in the callback, which leads to some interesting behaviour when trying to use incrementvar.

For example: `incrementvar proximity_voice_enabled 0 1 1` will return 0.00 instead of 0, which is considered truthy.

To remedy this, I have wrapped the `new` in a `tonumber()` so it will handle 0.00 as 0.